### PR TITLE
Fix vulnerability in Edgemicro auth

### DIFF
--- a/apiproxy/proxies/default.xml
+++ b/apiproxy/proxies/default.xml
@@ -117,6 +117,10 @@
                     <Name>AccessTokenRequest</Name>
                 </Step>
                 <Step>
+                    <Name>Raise-Fault-Unknown-Request</Name>
+                    <Condition>oauthV2.AccessTokenRequest.failed is true</Condition>
+                </Step>
+                <Step>
                     <FaultRules/>
                     <Name>Get-Private-Key</Name>
                 </Step>


### PR DESCRIPTION
The JWT access_token will be generated even client_secret or grant_type is an arbitrary string. This will fix it.