### PR TITLE
Only add approved products to apiProductsList

### DIFF
--- a/apiproxy/resources/jsc/set-jwt-variables.js
+++ b/apiproxy/resources/jsc/set-jwt-variables.js
@@ -22,7 +22,9 @@ try {
     credentials.forEach(function(credential) {
         if (credential.ConsumerKey == apiKey) {
             credential.ApiProducts.ApiProduct.forEach(function(apiProduct){
-                apiProductsList.push(apiProduct.Name);
+                if (apiProduct.Status === "approved") {
+                    apiProductsList.push(apiProduct.Name);
+                }
             });
         }
     });


### PR DESCRIPTION
Currently, when there's more than one product containing the edgemicro-auth proxy and the credentials are approved for one of those, the VerifyAPIKey policy will succeed.

Following this initial check, all products attached to the credentials in question will be sent back to edgemicro irrespective of their approval.