### PR TITLE
Fix typo in grant type

### DIFF
--- a/apiproxy/resources/jsc/validate-params.js
+++ b/apiproxy/resources/jsc/validate-params.js
@@ -16,7 +16,7 @@ function validateParams() {
         return;
     }
     
-    if (grant_type === 'pasword') {
+    if (grant_type === 'password') {
         if (username === '' || password === '') {
             context.setVariable('errText', 'missing username and/or password');
             return;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,5 +1,5 @@
 {
   "name": "microgateway-edgeauth",
-  "version": "2.4.17",
+  "version": "2.4.18",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microgateway-edgeauth",
-  "version": "2.4.17",
+  "version": "2.4.18",
   "description": "this proxy is used by microgateway to get a list of products, oauth tokens and api keys",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In apiproxy/resources/jsc/validate-params.js, the code has
`if (grant_type==='pasword')`