### PR TITLE
Use /authenticate endpoint for authentication

### DIFF
--- a/apiproxy/policies/Authenticate-Call.xml
+++ b/apiproxy/policies/Authenticate-Call.xml
@@ -9,7 +9,7 @@
                 <Header name="Authorization">{request.header.Authorization}</Header>
             </Headers>
             <Verb>GET</Verb>
-            <Path>/edgemicro/bootstrap/organization/{organization.name}/environment/{environment.name}</Path>
+            <Path>/edgemicro/authenticate/organization/{organization.name}/environment/{environment.name}</Path>
         </Set>
     </Request>
     <Response>calloutResponse</Response>


### PR DESCRIPTION
Stopped using /bootstrap endpoint for authentication to achieve performance
improvements