### PR TITLE
change bearer to Bearer in set-response.js

### DIFF
--- a/apiproxy/resources/jsc/set-response.js
+++ b/apiproxy/resources/jsc/set-response.js
@@ -24,7 +24,7 @@
     }
     
     jws.access_token = context.getVariable('jwtmessage');
-    jws.token_type   = "bearer";
+    jws.token_type   = "Bearer";
     jws.expires_in   = context.getVariable("token_expiry");
     
     //if refresh token exists, add it to response


### PR DESCRIPTION
When we integrate this oauth in swagger/yaml,

The swagger ui is fetching the token, but not able to use this token .

Bcause oauth plugin in microgateway specifically looking for "Bearer"
FYI In [oauth plugin code](https://github.com/apigee/microgateway-plugins/blob/v3.0.10/oauth/index.js) line 21 says `const authHeaderRegex = /Bearer (.+)/;`