### PR TITLE
Adding headers for CORS and changing the oauth type to Bearer

### DIFF
--- a/apiproxy/policies/Create-OAuth-Request.xml
+++ b/apiproxy/policies/Create-OAuth-Request.xml
@@ -3,6 +3,9 @@
     <DisplayName>Create OAuth Request</DisplayName>
     <FaultRules/>
     <Properties/>
+    <Copy source="request">
+        <Headers/>
+    </Copy>    
     <Set>
         <FormParams>
             <FormParam name="client_id">{client_id}</FormParam>

--- a/apiproxy/policies/Create-Refresh-Request.xml
+++ b/apiproxy/policies/Create-Refresh-Request.xml
@@ -3,6 +3,9 @@
     <DisplayName>Create Refresh Request</DisplayName>
     <FaultRules/>
     <Properties/>
+    <Copy source="request">
+        <Headers/>
+    </Copy>    
     <Set>
         <FormParams>
             <FormParam name="client_id">{client_id}</FormParam>

--- a/apiproxy/resources/jsc/set-response.js
+++ b/apiproxy/resources/jsc/set-response.js
@@ -24,7 +24,7 @@
     }
     
     jws.access_token = context.getVariable('jwtmessage');
-    jws.token_type   = "bearer";
+    jws.token_type   = "Bearer";
     jws.expires_in   = context.getVariable("token_expiry");
     
     //if refresh token exists, add it to response


### PR DESCRIPTION
Total three changes

---------------------------------------------------------------------------
1 and 2.  update to
`apiproxy/policies/Create-OAuth-Request.xml` and `apiproxy/policies/Create-Refresh-Request.xml`

Adding the copy headers to request. 
Currently when the request goes to backend, the headers are not being passed. And in case if we are implementing CORS, CORS fails because no request headers like Origin etc.

So copying the headers in assignmessage policy resolved the issue

----------------------------------------------------------------------------
3.   update to `apiproxy/resources/jsc/set-response.js` 

When we integrate this oauth in swagger/yaml,

The swagger ui is fetching the token, but not able to use this token .

Because oauth plugin in microgateway specifically looking for "Bearer"
FYI In [oauth plugin code](https://github.com/apigee/microgateway-plugins/blob/v3.0.10/oauth/index.js) line 21 says `const authHeaderRegex = /Bearer (.+)/;`


--------------------------------------------------------------------------------------------