### PR TITLE
b/179674670 edgemicro-auth - filter products by status

### DIFF
--- a/apiproxy/policies/Set-JWT-Variables.xml
+++ b/apiproxy/policies/Set-JWT-Variables.xml
@@ -2,6 +2,10 @@
 <Javascript timeLimit="20000" async="false" continueOnError="false" enabled="true" name="Set-JWT-Variables">
     <DisplayName>Set JWT Variables</DisplayName>
     <FaultRules/>
-    <Properties/>
+    <!--
+    <Properties>
+        <Property name="allowProductStatus">Approved</Property>
+    </Properties>
+    -->
     <ResourceURL>jsc://set-jwt-variables.js</ResourceURL>
 </Javascript>

--- a/apiproxy/resources/jsc/set-jwt-variables.js
+++ b/apiproxy/resources/jsc/set-jwt-variables.js
@@ -16,13 +16,27 @@ var apiCredential = JSON.parse(context.getVariable('apiCredential'));
 //{"Credentials":{"Credential":[{"Attributes":{},"ConsumerKey":"xxx","ConsumerSecret":"xx","ExpiresAt":"-1","IssuedAt":"1530046158362","ApiProducts":{"ApiProduct":{"Name":"details product","Status":"approved"}},"Scopes":{},"Status":"approved"}]}}
 var credentials = apiCredential.Credentials.Credential;
 
+var allowedStatus = properties.allowProductStatus;
+var productAllowedStatus=[];
+
+try{
+    productAllowedStatus = allowedStatus.toLowerCase().split(',');
+}catch (err) {
+}
+
 var apiProductsList = [];
 try {
     var apiKey = context.getVariable('apikey').trim();
     credentials.forEach(function(credential) {
         if (credential.ConsumerKey == apiKey) {
             credential.ApiProducts.ApiProduct.forEach(function(apiProduct){
-                apiProductsList.push(apiProduct.Name);
+                if(productAllowedStatus && productAllowedStatus.length>0){
+                    if(productAllowedStatus.indexOf(apiProduct.Status.toLowerCase()) != -1){
+                        apiProductsList.push(apiProduct.Name);
+                    }
+                }else{
+                    apiProductsList.push(apiProduct.Name);
+                }
             });
         }
     });


### PR DESCRIPTION
Add property 'allowProductStatus' in 'Set JWT Variables' policy to allow filtering of products based on status codes.
Eg: <Property name="allowProductStatus">Approved</Property>

Incase, property 'allowProductStatus' is not defined, then products with all status codes will get filtered.

To allow products with multiple status codes, use comma separated values.
Eg: <Property name="allowProductStatus">Approved,Pending</Property>

Allowed status codes are Approved, Pending, & Revoked