### PR TITLE
Set expires_in as number instead of string

### DIFF
--- a/apiproxy/resources/jsc/set-response.js
+++ b/apiproxy/resources/jsc/set-response.js
@@ -27,7 +27,7 @@
     jws.token_type   = "Bearer";
 
      // for /token flow
-     jws.expires_in = context.getVariable("oauthv2accesstoken.AccessTokenRequest.expires_in");
+     jws.expires_in = parseInt(context.getVariable("oauthv2accesstoken.AccessTokenRequest.expires_in"));
 
      // for any other flows if any 
     if ( !jws.expires_in ) {


### PR DESCRIPTION
As per spec https://tools.ietf.org/html/rfc6749#section-4.1.4 shows an integer, not a string.
and rfc6749 section 5.1 notes:

```
Parameter names and string values are included as JSON strings.
Numerical values are included as JSON numbers. The order of
parameters does not matter and can vary.
```

Changing expires_in to be as number

