### PR TITLE
185323500 JWT-expires_in convert to integer

### DIFF
--- a/apiproxy/resources/jsc/set-response.js
+++ b/apiproxy/resources/jsc/set-response.js
@@ -32,6 +32,8 @@
      // for any other flows if any 
     if ( !jws.expires_in ) {
       jws.expires_in   = parseInt( context.getVariable("token_expiry"), 10) / 1000; // convert to seconds
+    }else {
+      jws.expires_in = parseInt( jws.expires_in );
     }
     
     //if refresh token exists, add it to response


### PR DESCRIPTION
edgemicro token command, will return 'expires_in' as an integer.

command:
edgemicro token get -o{org} -e{env} -i {app key} -s{app secret}

sample output:
{
  "token": "eyJraWQiOiIxMSIsInR5cCI6I...",
  "scope": "Admin",
  "access_token": "eyJraWQiOiIxMSIsInR5cCI6...",
  "token_type": "Bearer",
  "expires_in": 1799
}